### PR TITLE
Implement in memory storage

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -1,6 +1,6 @@
-use std::net::{TcpStream};
+use bincode::{deserialize_from, serialize_into};
 use std::io::*;
-use bincode::{serialize_into, deserialize_from};
+use std::net::TcpStream;
 
 pub fn from_stdin() {
     let mut stream = TcpStream::connect("127.0.0.1:12345").unwrap();

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,8 +2,7 @@ use std::error;
 use std::fmt;
 
 #[derive(Debug)]
-pub enum Error {
-}
+pub enum Error {}
 
 impl error::Error for Error {}
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 //mod predicate;
+mod client;
 mod error;
 mod server;
-mod client;
 
 use std::env;
 
@@ -13,4 +13,3 @@ fn main() {
         server::server()
     }
 }
-

--- a/src/server/execute.rs
+++ b/src/server/execute.rs
@@ -1,7 +1,16 @@
 use crate::server::operators::Op;
 use crate::{error::Error, server::record::Record};
+use std::sync::mpsc::Sender;
 
-pub fn execute(operation: Op) -> Result<Option<Vec<Record>>, Error> {
-    println!("{:?}", operation);
-    Ok(None)
+pub fn execute(operation: Op, tx: &Sender<Record>) -> Result<Option<Vec<Record>>, Error> {
+    match operation {
+        Op::Write(record) => execute_write(record, tx),
+        _ => Ok(None),
+    }
+}
+
+fn execute_write(record: Record, tx: &Sender<Record>) -> Result<Option<Vec<Record>>, Error> {
+    let record_dup = record.clone();
+    tx.send(record).unwrap();
+    Ok(Some(vec![record_dup]))
 }

--- a/src/server/execute.rs
+++ b/src/server/execute.rs
@@ -1,11 +1,7 @@
 use crate::server::operators::Op;
-use crate::{
-    error::Error,
-    server::record::Record,
-};
+use crate::{error::Error, server::record::Record};
 
 pub fn execute(operation: Op) -> Result<Option<Vec<Record>>, Error> {
     println!("{:?}", operation);
     Ok(None)
 }
-

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1,6 +1,6 @@
-mod server;
+mod execute;
 mod operators;
 mod record;
-mod execute;
+mod server;
 
 pub use server::server;

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -2,5 +2,6 @@ mod execute;
 mod operators;
 mod record;
 mod server;
+mod store;
 
 pub use server::server;

--- a/src/server/operators/mod.rs
+++ b/src/server/operators/mod.rs
@@ -13,7 +13,7 @@ pub enum Op {
 #[cfg(test)]
 mod test {
     use super::*;
-    use chrono::{NaiveDateTime, DateTime, Utc};
+    use chrono::{DateTime, NaiveDateTime, Utc};
     use std::collections::HashMap;
 
     #[test]
@@ -39,7 +39,9 @@ mod test {
         let mut variables = HashMap::new();
         variables.insert("usage_user".to_string(), 58.0);
         variables.insert("usage_system".to_string(), 2.0);
-        let timestamp = DateTime::parse_from_rfc3339("2016-06-13T17:43:50.1004002+00:00").unwrap().with_timezone(&Utc);
+        let timestamp = DateTime::parse_from_rfc3339("2016-06-13T17:43:50.1004002+00:00")
+            .unwrap()
+            .with_timezone(&Utc);
 
         let d: Op = serde_json::from_str(data).unwrap();
         let exp = Op::Write(Record::new("cpu".to_string(), labels, variables, timestamp));

--- a/src/server/operators/select.rs
+++ b/src/server/operators/select.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub struct Select {
     name: String,
-    predicate: Predicate
+    predicate: Predicate,
 }
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
@@ -60,7 +60,7 @@ mod test {
         let exp = Condition {
             lhs: Type::LabelKey(String::from("Key")),
             rhs: Type::LabelValue(String::from("Value")),
-            op: Op::Eq
+            op: Op::Eq,
         };
         assert_eq!(d, exp);
     }
@@ -78,13 +78,11 @@ mod test {
         "#;
 
         let d: Conditions = serde_json::from_str(data).unwrap();
-        let exp = Conditions::Leaf(
-            Condition {
-                lhs: Type::Variable(String::from("Var")),
-                rhs: Type::Metric(6.0),
-                op: Op::Gt
-            }
-        );
+        let exp = Conditions::Leaf(Condition {
+            lhs: Type::Variable(String::from("Var")),
+            rhs: Type::Metric(6.0),
+            op: Op::Gt,
+        });
         assert_eq!(d, exp);
 
         let data = r#"
@@ -101,26 +99,17 @@ mod test {
         "#;
         let d: Conditions = serde_json::from_str(data).unwrap();
         let exp = Conditions::And(
-            Box::new(
-                Conditions::Leaf(
-                    Condition {
-                        lhs: Type::LabelKey(String::from("Key")),
-                        rhs: Type::LabelValue(String::from("Value")),
-                        op: Op::Eq
-                    }
-                )
-            ),
-            Box::new(
-                Conditions::Leaf(
-                    Condition {
-                        lhs: Type::Variable(String::from("Var")),
-                        rhs: Type::Metric(6.0),
-                        op: Op::Gt
-                    }
-                )
-            ),
+            Box::new(Conditions::Leaf(Condition {
+                lhs: Type::LabelKey(String::from("Key")),
+                rhs: Type::LabelValue(String::from("Value")),
+                op: Op::Eq,
+            })),
+            Box::new(Conditions::Leaf(Condition {
+                lhs: Type::Variable(String::from("Var")),
+                rhs: Type::Metric(6.0),
+                op: Op::Gt,
+            })),
         );
         assert_eq!(d, exp);
     }
 }
-

--- a/src/server/record.rs
+++ b/src/server/record.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, PartialEq, Deserialize, Serialize, Clone)]
 pub struct Record {
     name: String,
     labels: HashMap<String, String>,

--- a/src/server/record.rs
+++ b/src/server/record.rs
@@ -12,7 +12,12 @@ pub struct Record {
 }
 
 impl Record {
-    pub fn new(name: String, labels: HashMap<String, String>, variables: HashMap<String, f64>, timestamp: DateTime<Utc>) -> Self {
+    pub fn new(
+        name: String,
+        labels: HashMap<String, String>,
+        variables: HashMap<String, f64>,
+        timestamp: DateTime<Utc>,
+    ) -> Self {
         Record {
             name,
             labels,
@@ -55,11 +60,11 @@ mod test {
             name: "cpu".to_string(),
             labels: labels,
             variables: variables,
-            timestamp: DateTime::parse_from_rfc3339("2016-06-13T17:43:50.1004002+00:00").unwrap().with_timezone(&Utc)
+            timestamp: DateTime::parse_from_rfc3339("2016-06-13T17:43:50.1004002+00:00")
+                .unwrap()
+                .with_timezone(&Utc),
         };
 
         assert_eq!(exp, d);
     }
 }
-
-

--- a/src/server/server.rs
+++ b/src/server/server.rs
@@ -1,17 +1,12 @@
 use std::{
-    net::{TcpListener, TcpStream, Shutdown},
+    io,
+    net::{Shutdown, TcpListener, TcpStream},
     thread,
-    io
 };
 
-use bincode::{serialize_into, deserialize_from};
+use bincode::{deserialize_from, serialize_into};
 
-use crate::{
-    server::{
-        execute::execute,
-        record::Record,
-    },
-};
+use crate::server::{execute::execute, record::Record};
 
 fn postprocess(result: Vec<Record>) -> String {
     let _ = result;
@@ -36,7 +31,7 @@ fn handle_tcp_connection(mut stream: TcpStream) {
                 serialize_into(&mut stream, &response).unwrap();
                 true
             }
-        },
+        }
         Err(_) => false,
     } {}
 
@@ -46,7 +41,7 @@ fn handle_tcp_connection(mut stream: TcpStream) {
         Err(err) => match err.kind() {
             io::ErrorKind::NotConnected => println!("Connection already terminated"),
             _ => panic!("Shutdown problem"),
-        }
+        },
     }
 }
 

--- a/src/server/store.rs
+++ b/src/server/store.rs
@@ -1,0 +1,14 @@
+use std::sync::mpsc::Receiver;
+
+use crate::server::record::Record;
+
+pub fn db_open(write_rx: Receiver<Record>) {
+    // Create an in-memory storage structure
+    let mut storage: Vec<Record> = Vec::new();
+
+    // Receive write operations from the server
+    for received in write_rx {
+        storage.push(received);
+        println!("Total records in storage: {}", storage.len());
+    }
+}


### PR DESCRIPTION
This is a proposed in-memory implementation of our storage layer where all incoming records are appended onto a single vector.

Additionally, I propose to run a separate thread (and possibly multiple threads, depending on how many cores we have, and the cost of context switching in Rust) for our storage interface. Executes are handled by passing messages to the storage interface either via a write channel or a query channel, and results are sent back via a separate (possibly thread-specific) channel.